### PR TITLE
Feature bl 19106 update terraform action for artifact name

### DIFF
--- a/.github/actions/terraform-action/action.yml
+++ b/.github/actions/terraform-action/action.yml
@@ -41,6 +41,14 @@ inputs:
     type: string
     default: '.'
     description: Directory location of Terraform
+  artifact_name:
+    type: string
+    default: ''
+    description: 'Name of the artifact to upload (defaults to environment-component if empty)'
+  upload_artifact:
+    type: boolean
+    default: true
+    description: 'Whether to upload the artifact or not'
 
 runs:
   using: 'composite'
@@ -59,8 +67,9 @@ runs:
       shell: bash
 
     - name: Save Artifact
+      if: ${{ inputs.upload_artifact }}
       uses: actions/upload-artifact@v4
       with:
-        name: "${{ inputs.environment }}-${{ inputs.component }}"
+        name: "${{ inputs.artifact_name != '' && inputs.artifact_name || format('{0}-{1}', inputs.environment, inputs.component) }}"
         path: "${{ inputs.terraform_directory }}/plans/${{ inputs.environment }}/${{ inputs.component }}-plan.txt"
         retention-days: 7

--- a/.github/actions/terraform-action/action.yml
+++ b/.github/actions/terraform-action/action.yml
@@ -66,10 +66,15 @@ runs:
         ./bin/terraform.sh --action ${{ inputs.action }} --project ${{ inputs.project }} --environment ${{ inputs.environment }}  --component ${{ inputs.component }} --group ${{ inputs.group }} --bucket-prefix ${{ inputs.bucket-prefix }} --region ${{ inputs.region }} --compact-warnings --no-color -- ${{ inputs.terraform_args }} | tee plans/${{ inputs.environment }}/${{ inputs.component }}-plan.txt
       shell: bash
 
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d-%H-%M-%S')" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Save Artifact
       if: ${{ inputs.upload_artifact }}
       uses: actions/upload-artifact@v4
       with:
-        name: "${{ inputs.artifact_name != '' && inputs.artifact_name || format('{0}-{1}', inputs.environment, inputs.component) }}"
+        name: "${{ inputs.artifact_name != '' && format('{0}-{1}-{2}-{3}', inputs.environment, inputs.component, inputs.artifact_name, steps.date.outputs.date) || format('{0}-{1}-{2}', inputs.environment, inputs.component, steps.date.outputs.date) }}"
         path: "${{ inputs.terraform_directory }}/plans/${{ inputs.environment }}/${{ inputs.component }}-plan.txt"
         retention-days: 7


### PR DESCRIPTION
## Description

The main purpose of this PR is to enable the Terraform actions workflow to add a custom name for the artefact, since running both plan and apply workflows results in an artefact name conflict, preventing the saving of apply artefacts.

The following changes enable:
- Give a custom name for workflow (e.g. plan, apply)
- Add date and time of the workflow run to the artefact name to help easily locate the searched artefact.

Related issue: [BL-19106](https://dvsa.atlassian.net/jira/software/c/projects/BL/boards/975?selectedIssue=BL-19106)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?

Example worfklow result:
![image](https://github.com/user-attachments/assets/3ff9f435-355f-4bf2-b905-ed8cfb90da2d)

